### PR TITLE
`is_public` was a lie

### DIFF
--- a/check_process
+++ b/check_process
@@ -7,35 +7,21 @@
 	; Manifest
 		domain="domain.tld"	(DOMAIN)
 		path="/path"	(PATH)
-		is_public=1	(PUBLIC|public=1|private=0)
-		redirect_type="visible_302"
+		redirect_type="public_302"
 		redirect_path="http://127.0.0.1"
 	; Checks
 		pkg_linter=1
 		setup_sub_dir=1
 		setup_root=1
 		setup_nourl=0
-		setup_private=1
+		setup_private=0
 		setup_public=1
 		upgrade=1
 		backup_restore=1
 		multi_instance=1
-		incorrect_path=1
+		incorrect_path=0
 		port_already_use=0
 		change_url=0
-;;; Levels
-	Level 1=auto
-	Level 2=auto
-	Level 3=auto
-# Level 4:
-	Level 4=0
-# Level 5:
-	Level 5=auto
-	Level 6=auto
-	Level 7=auto
-	Level 8=0
-	Level 9=0
-	Level 10=0
 ;;; Options
 Email=
 Notification=none

--- a/manifest.json
+++ b/manifest.json
@@ -52,30 +52,18 @@
                 "default": "http://127.0.0.1"
             },
             {
-                "name": "is_public",
-                "type": "boolean",
-                "ask": {
-                    "en": "Is it a public redirect?",
-                    "fr": "Est-ce une redirection publique ?"
-                },
-                "help": {
-                    "en": "A private redirection will only be effective for logged-in users.",
-                    "fr": "Une redirection privée ne fonctionnera que pour les utilisateurs identifiés."
-                },
-                "default": false
-            },
-            {
                 "name": "redirect_type",
                 "ask": {
                     "en": "Redirect type",
                     "fr": "Type de redirection"
                 },
                 "choices": {
-                  "visible_302" : "Visible (302, temporary redirect)",
-                  "visible_301" : "Visible (301, permanent redirect)",
-                  "proxy": "Proxy, invisible (Nginx proxy_pass)"
+                  "public_302" : "Visible redirect (302, temporary). Everybody will be able to access it.",
+                  "public_301" : "Visible redirect (301, permanent). Everybody will be able to access it.",
+                  "public_proxy": "Proxy, invisible (nginx proxy_pass). Everybody will be able to access it.",
+                  "private_proxy": "Proxy, invisible (nginx proxy_pass). Only accessible for allowed users."
                 },
-                "default": "visible_302"
+                "default": "public_302"
             }
         ]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "en": "Create a redirection or a proxy to another path.",
         "fr": "Créer une redirection ou un proxy vers un autre emplacement"
     },
-    "version": "1.0.0~ynh3",
+    "version": "1.0.0~ynh4",
     "license": "AGPL-3.0-or-later",
     "url": "https://github.com/YunoHost-Apps/redirect_ynh",
     "maintainer": {

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,12 +6,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# if [ ! -e _common.sh ]; then
-	# Get the _common.sh file if it's not in the current directory
-# 	cp ../settings/scripts/_common.sh ./_common.sh
-# 	chmod a+rx _common.sh
-# fi
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -25,21 +19,9 @@ ynh_abort_if_errors
 # LOAD SETTINGS
 #=================================================
 
-# This is a multi-instance app, meaning it can be installed several times independently
-# The id of the app as stated in the manifest is available as $YNH_APP_ID
-# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
-# The app instance name is available as $YNH_APP_INSTANCE_NAME
-#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
-#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
-#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
-# The app instance name is probably what you are interested the most, since this is
-# guaranteed to be unique. This is a good unique identifier to define installation path,
-# db names, ...
-app=$YNH_APP_INSTANCE_NAME
-
 # Retrieve arguments
+app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)
 
 # Copy the conf files
-mkdir -p ./conf
-cp -a "/etc/nginx/conf.d/${domain}.d/${app}.conf" ./conf/nginx.conf
+ynh_backup "/etc/nginx/conf.d/${domain}.d/${app}.conf"

--- a/scripts/install
+++ b/scripts/install
@@ -35,7 +35,6 @@ app=$YNH_APP_INSTANCE_NAME
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
-is_public=$YNH_APP_ARG_IS_PUBLIC
 redirect_type=$YNH_APP_ARG_REDIRECT_TYPE
 redirect_path=$YNH_APP_ARG_REDIRECT_PATH
 
@@ -47,7 +46,6 @@ url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=
 [[ ! $redirect_path =~ $url_regex ]] && ynh_die "Invalid destination: $redirect_path" 1
 
 # Save extra settings
-ynh_app_setting_set $app is_public "$is_public"
 ynh_app_setting_set $app redirect_type "$redirect_type"
 ynh_app_setting_set $app redirect_path "$redirect_path"
 
@@ -56,15 +54,15 @@ for FILE in $(ls ../conf/nginx-*.conf)
 do
     ynh_replace_string "YNH_LOCATION" "$path_url" $FILE
 done
-if [ "$redirect_type" = "visible_302" ];
+if [ "$redirect_type" = "public_302" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-visible-302.conf
     cp ../conf/nginx-visible-302.conf /etc/nginx/conf.d/$domain.d/$app.conf
-elif [ "$redirect_type" = "visible_301" ];
+elif [ "$redirect_type" = "public_301" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-visible-301.conf
     cp ../conf/nginx-visible-301.conf /etc/nginx/conf.d/$domain.d/$app.conf
-elif [ "$redirect_type" = "proxy" ];
+elif [ "$redirect_type" = "public_proxy" ] || [ "$redirect_type" = "private_proxy" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-proxy.conf
     cp ../conf/nginx-proxy.conf /etc/nginx/conf.d/$domain.d/$app.conf
@@ -74,17 +72,12 @@ fi
 # SETUP SSOWAT
 #=================================================
 
-if [ $is_public -eq 0 ]
-then	# Remove the public access
-	ynh_app_setting_delete "$app" skipped_uris
-fi
 # Make app public if necessary
-if [ $is_public -eq 1 ]
+if [ "$redirect_type" != "private_proxy" ]
 then
 	# unprotected_uris allows SSO credentials to be passed anyway.
 	ynh_app_setting_set "$app" unprotected_uris "/"
 fi
-
 
 # Reload Nginx and regenerate SSOwat conf
 service nginx reload

--- a/scripts/install
+++ b/scripts/install
@@ -6,7 +6,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -20,19 +19,8 @@ ynh_abort_if_errors
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
-# This is a multi-instance app, meaning it can be installed several times independently
-# The id of the app as stated in the manifest is available as $YNH_APP_ID
-# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
-# The app instance name is available as $YNH_APP_INSTANCE_NAME
-#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
-#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
-#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
-# The app instance name is probably what you are interested the most, since this is
-# guaranteed to be unique. This is a good unique identifier to define installation path,
-# db names, ...
-app=$YNH_APP_INSTANCE_NAME
-
 # Retrieve arguments
+app=$YNH_APP_INSTANCE_NAME
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 redirect_type=$YNH_APP_ARG_REDIRECT_TYPE
@@ -48,6 +36,10 @@ url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=
 # Save extra settings
 ynh_app_setting_set $app redirect_type "$redirect_type"
 ynh_app_setting_set $app redirect_path "$redirect_path"
+
+#=================================================
+# CONFIGURE NGINX
+#=================================================
 
 # Nginx configuration
 for FILE in $(ls ../conf/nginx-*.conf)
@@ -69,7 +61,7 @@ then
 fi
 
 #=================================================
-# SETUP SSOWAT
+# CONFIGURE SSOWAT
 #=================================================
 
 # Make app public if necessary
@@ -80,4 +72,4 @@ then
 fi
 
 # Reload Nginx and regenerate SSOwat conf
-service nginx reload
+systemctl reload nginx

--- a/scripts/remove
+++ b/scripts/remove
@@ -6,30 +6,18 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
 # LOAD SETTINGS
 #=================================================
 
-# This is a multi-instance app, meaning it can be installed several times independently
-# The id of the app as stated in the manifest is available as $YNH_APP_ID
-# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
-# The app instance name is available as $YNH_APP_INSTANCE_NAME
-#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
-#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
-#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
-# The app instance name is probably what you are interested the most, since this is
-# guaranteed to be unique. This is a good unique identifier to define installation path,
-# db names, ...
-app=$YNH_APP_INSTANCE_NAME
-
 # Retrieve arguments
+app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)
 
 # Remove configuration files
 ynh_secure_remove /etc/nginx/conf.d/$domain.d/$app.conf
 
 # Restart services
-service nginx reload
+systemctl reload nginx

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,12 +6,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# if [ ! -e _common.sh ]; then
-	# Get the _common.sh file if it's not in the current directory
-# 	cp ../settings/scripts/_common.sh ./_common.sh
-# 	chmod a+rx _common.sh
-# fi
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -25,19 +19,8 @@ ynh_abort_if_errors
 # LOAD SETTINGS
 #=================================================
 
-# This is a multi-instance app, meaning it can be installed several times independently
-# The id of the app as stated in the manifest is available as $YNH_APP_ID
-# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
-# The app instance name is available as $YNH_APP_INSTANCE_NAME
-#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
-#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
-#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
-# The app instance name is probably what you are interested the most, since this is
-# guaranteed to be unique. This is a good unique identifier to define installation path,
-# db names, ...
-app=$YNH_APP_INSTANCE_NAME
-
 # Retrieve arguments
+app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
 redirect_type=$(ynh_app_setting_get "$app" redirect_type)
@@ -52,10 +35,10 @@ NGINX_CONF="/etc/nginx/conf.d/${domain}.d/${app}.conf"
 [[ -f $NGINX_CONF ]] && ynh_die "The NGINX configuration already exists at '${NGINX_CONF}'. You should safely delete it before restoring this app."
 
 # Restore configuration files
-cp -a ./conf/nginx.conf "$NGINX_CONF"
+ynh_restore_file "$NGINX_CONF"
 
 #=================================================
-# SETUP SSOWAT
+# CONFIGURE SSOWAT
 #=================================================
 
 # Make app public if necessary
@@ -66,4 +49,4 @@ then
 fi
 
 # Reload Nginx and regenerate SSOwat conf
-service nginx reload
+systemctl reload nginx

--- a/scripts/restore
+++ b/scripts/restore
@@ -40,7 +40,6 @@ app=$YNH_APP_INSTANCE_NAME
 # Retrieve arguments
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
-is_public=$(ynh_app_setting_get "$app" is_public)
 redirect_type=$(ynh_app_setting_get "$app" redirect_type)
 redirect_path=$(ynh_app_setting_get "$app" redirect_path)
 
@@ -59,12 +58,8 @@ cp -a ./conf/nginx.conf "$NGINX_CONF"
 # SETUP SSOWAT
 #=================================================
 
-if [ "$is_public" -eq 0 ]
-then	# Remove the public access
-	ynh_app_setting_delete "$app" skipped_uris
-fi
 # Make app public if necessary
-if [ "$is_public" -eq 1 ]
+if [ "$redirect_type" != "private_proxy" ]
 then
 	# unprotected_uris allows SSO credentials to be passed anyway.
 	ynh_app_setting_set "$app" unprotected_uris "/"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,7 +32,6 @@ app=$YNH_APP_INSTANCE_NAME
 # Retrieve arguments
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
-is_public=$(ynh_app_setting_get "$app" is_public)
 redirect_type=$(ynh_app_setting_get "$app" redirect_type)
 redirect_path=$(ynh_app_setting_get "$app" redirect_path)
 
@@ -41,20 +40,46 @@ redirect_path=$(ynh_app_setting_get "$app" redirect_path)
 #=================================================
 
 # Fix is_public as a boolean value
-if [ "$is_public" = "Yes" ]; then
-	ynh_app_setting_set $app is_public 1
-	is_public=1
-elif [ "$is_public" = "No" ]; then
-	ynh_app_setting_set $app is_public 0
-	is_public=0
-fi
-
 # Default value for redirect_type if upgrading from https://github.com/scith/redirect_ynh
 if [ -z "$redirect_type" ];
 then
     redirect_type="proxy"
     ynh_app_setting_set $app 'redirect_type' $redirect_type
 fi
+
+# Migrate away from old stuff with 'is_public' and old redirect type names
+is_public=$(ynh_app_setting_get "$app" is_public)
+if [ -n "$is_public" ]
+then
+    if [ "$is_public" = "Yes" ]; then
+        is_public=1
+    elif [ "$is_public" = "No" ]; then
+        is_public=0
+    fi
+
+    if [ "$is_public" = "0" ] && [ "$redirect_type" != "proxy" ]; then
+       echo "WARNING: You previously had a 'supposedly' private 301 or 302 redirection ... but it was found that it was public all along and it is not easy to create such a private redirection. Your 301 or 302 redirection will be re-flagged as public..." >&2
+       is_public=1
+    fi
+
+    if [ "$redirect_type" == "proxy" ] && [ "$is_public" = "1" ]
+    then
+        redirect_type="public_proxy"
+    elif [ "$redirect_type" == "proxy" ] && [ "$is_public" = "0" ]
+    then
+        redirect_type="private_proxy"
+    elif [ "$redirect_type" == "visible_302" ]
+    then
+        redirect_type="public_302"
+    elif [ "$redirect_type" == "visible_301" ]
+    then
+        redirect_type="public_301"
+    fi
+    
+    ynh_app_setting_set $app 'redirect_type' $redirect_type
+    ynh_app_setting_set $app 'is_public'
+fi
+
 
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
@@ -78,15 +103,15 @@ for FILE in $(ls ../conf/nginx-*.conf)
 do
     ynh_replace_string "YNH_LOCATION" "$path_url" $FILE
 done
-if [ "$redirect_type" = "visible_302" ];
+if [ "$redirect_type" = "public_302" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-visible-302.conf
     cp ../conf/nginx-visible-302.conf /etc/nginx/conf.d/$domain.d/$app.conf
-elif [ "$redirect_type" = "visible_301" ];
+elif [ "$redirect_type" = "public_301" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-visible-301.conf
     cp ../conf/nginx-visible-301.conf /etc/nginx/conf.d/$domain.d/$app.conf
-elif [ "$redirect_type" = "proxy" ];
+elif [ "$redirect_type" = "public_proxy" ] || [ "$redirect_type" = "private_proxy" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-proxy.conf
     cp ../conf/nginx-proxy.conf /etc/nginx/conf.d/$domain.d/$app.conf
@@ -96,15 +121,11 @@ fi
 # SETUP SSOWAT
 #=================================================
 
-if [ "$is_public" -eq 0 ]
-then	# Remove the public access
-	ynh_app_setting_delete "$app" skipped_uris
-fi
 # Make app public if necessary
-if [ "$is_public" -eq 1 ]
+if [ "$redirect_type" != "private_proxy" ]
 then
 	# unprotected_uris allows SSO credentials to be passed anyway.
-	ynh_app_setting_set "$app" unprotected_uris -v "/"
+	ynh_app_setting_set "$app" unprotected_uris "/"
 fi
 
 # Reload Nginx and regenerate SSOwat conf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,29 +7,14 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
 # LOAD SETTINGS
 #=================================================
 
-# This is a multi-instance app, meaning it can be installed several times independently
-# The id of the app as stated in the manifest is available as $YNH_APP_ID
-# The instance number is available as $YNH_APP_INSTANCE_NUMBER (equals "1", "2", ...)
-# The app instance name is available as $YNH_APP_INSTANCE_NAME
-#    - the first time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample
-#    - the second time the app is installed, YNH_APP_INSTANCE_NAME = ynhexample__2
-#    - ynhexample__{N} for the subsequent installations, with N=3,4, ...
-# The app instance name is probably what you are interested the most, since this is
-# guaranteed to be unique. This is a good unique identifier to define installation path,
-# db names, ...
-app=$YNH_APP_INSTANCE_NAME
-
-# Source app helpers
-. /usr/share/yunohost/helpers
-
 # Retrieve arguments
+app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
 redirect_type=$(ynh_app_setting_get "$app" redirect_type)
@@ -98,6 +83,10 @@ ynh_abort_if_errors
 url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
 [[ ! $redirect_path =~ $url_regex ]] && ynh_die "Invalid destination: $redirect_path" 1
 
+#=================================================
+# CONFIGURE NGINX
+#=================================================
+
 # Nginx configuration
 for FILE in $(ls ../conf/nginx-*.conf)
 do
@@ -118,7 +107,7 @@ then
 fi
 
 #=================================================
-# SETUP SSOWAT
+# CONFIGURE SSOWAT
 #=================================================
 
 # Make app public if necessary
@@ -129,4 +118,4 @@ then
 fi
 
 # Reload Nginx and regenerate SSOwat conf
-service nginx reload
+systemctl reload nginx


### PR DESCRIPTION
As revealed by the CI, there was a weird issue about installation in private mode ...

https://ci-apps-dev.yunohost.org/jenkins/view/aleks/job/redirect_ynh%20(aleks)/10/console

I thought that was a small bug, but turns out (at least that's my understanding) that there's a fundamental issue with implementing a private 301 or 302 redirection ... 

The nginx config looks like this : 

```
location /foo {
  return 302 https://bar.com;
}
```

For such a small config with a `return` inside it, I found that the request is **not** handled by SSOwat at all. (One clue among all is the lack of header X-SSOwat as usually found in other contexts). So it never checks if the user is or not logged in, or anything related to ssowat in general (protected_urls, ...)

Note that this does not affect traditional `proxy_pass` blocks, so the reverse-proxy case of the app works correctly.

I thought about alternative solution using `redirected_urls` in ssowat configuration, but there's actually no way to do a *protected* redirect without having to change the code of ssowat.

But imho there's not such a big use case for protected 301 or 302 redirect ... (One could even argue that a protected 301 redirect is nonsense/dangerous since it get stored in the browser's cache).

Bottom line is : I reworked the whole is_public and redirect_type thing to fix this.

I'm opening this PR in case people want to provide feedback, but I plan to merge it in a few days if there's no complain. 

Job 11 is pending on https://ci-apps-dev.yunohost.org/jenkins/job/redirect_ynh%20(aleks)/