### PR TITLE
[fix] Avoid remote unencrypted destination in proxy mode

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=
 
 # Avoid uncrypted remote destination with reverse proxy mode
 # Indeed the SSO send the password in all requests in HTTP headers
-url_regex='(http://(127.\d+.\d+.\d+|localhost)(:\d+)?/|https://)[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+url_regex='^(http://(127\.[0-9]+\.[0-9]+\.[0-9]+|localhost)|https://.*)(:[0-9]+)?(/.*)?$'
 [[ "$redirect_type" = "proxy" ]] && [[ ! $redirect_path =~ $url_regex ]] && ynh_die \
 "For secure reason, you can't use an unencrypted http remote destination couple with ssowat for your reverse proxy: $redirect_path" 1
 

--- a/scripts/install
+++ b/scripts/install
@@ -53,6 +53,12 @@ url_regex='(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=
 [[ ! $redirect_path =~ $url_regex ]] && ynh_die \
 "Invalid destination: $redirect_path" 1
 
+# Avoid uncrypted remote destination with reverse proxy mode
+# Indeed the SSO send the password in all requests in HTTP headers
+url_regex='(http://(127.\d+.\d+.\d+|localhost)(:\d+)?/|https://)[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+[[ "$redirect_type" = "proxy" ]] && [[ ! $redirect_path =~ $url_regex ]] && ynh_die \
+"For secure reason, you can't use an unencrypted http remote destination couple with ssowat for your reverse proxy: $redirect_path" 1
+
 # Save extra settings
 yunohost app setting $app is_public -v "$is_public"
 yunohost app setting $app redirect_type -v "$redirect_type"


### PR DESCRIPTION
## The problem
Use http with the reverse proxy mode could leaks some important data from the sso.

## The solution
Avoid the user to create a proxy with an unencrypted http remote url.

## State
Ready and tested