### PR TITLE
Added direct proxy to allow redirecting a domain to another application.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ In case of a private redirect, the app will be available to logged in users only
 
 **IMPORTANT:** Make sure that the app you want to protect CANNOT be accessed by its port or another direct link. Otherwise, your app will only be protected in YunoHost but would still be available through its direct link. In the case of a Docker container, the port of the container will have to be local (e.g., -p 127.0.0.1:9000:9000).
 
+## Direct redirect
+
+The standard public redirect can fail when trying to redirect a web application (or another domain). When redirecting one application to another domain, use this option.
+
 ## Case examples
 
 - **Creating a tile for a Docker container** with a local port (e.g., -p 127.0.0.1:PORT:PORT): proxy redirect to http://127.0.0.1:PORT-OF-THE-CONTAINER/
@@ -44,6 +48,8 @@ In case of a private redirect, the app will be available to logged in users only
 - [CozyCloud behind YunoHost?](https://forum.cozy.io/t/cozy-cloud-sous-yunohost/616/11)
 
 - **Creating a tile and protecting apps that are difficult to package natively (or for prototyping)**
+
+- **Pointing another domain to the same app**: Proxy, invisible direct. Select your domain and the redirect path, for example: www.myapp.com/ -> myapp.mydomain.com/
 
 
 **_Feel free to [share your case examples and customized Nginx files on the forum](https://forum.yunohost.org/t/2182)._**

--- a/conf/nginx-proxy-direct.conf
+++ b/conf/nginx-proxy-direct.conf
@@ -1,0 +1,9 @@
+location YNH_LOCATION {
+  proxy_pass        YNH_REDIRECT_PATH;
+  
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+
+  more_clear_input_headers 'Accept-Encoding';
+}

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "en": "Create a redirection or a proxy to another path.",
         "fr": "Créer une redirection ou un proxy vers un autre emplacement"
     },
-    "version": "1.0.0~ynh4",
+    "version": "1.0.0~ynh5",
     "license": "AGPL-3.0-or-later",
     "url": "https://github.com/YunoHost-Apps/redirect_ynh",
     "maintainer": {
@@ -61,7 +61,7 @@
                   "public_302" : "Visible redirect (302, temporary). Everybody will be able to access it.",
                   "public_301" : "Visible redirect (301, permanent). Everybody will be able to access it.",
                   "public_proxy": "Proxy, invisible (nginx proxy_pass). Everybody will be able to access it.",
-				  "public_direct": "Proxy, invisible direct (nginx proxy_pass). Everybody will be able to access it. No forward headers.",
+                  "public_direct": "Proxy, invisible direct (nginx proxy_pass). Everybody will be able to access it. No forward headers.",
                   "private_proxy": "Proxy, invisible (nginx proxy_pass). Only accessible for allowed users."
                 },
                 "default": "public_302"

--- a/manifest.json
+++ b/manifest.json
@@ -61,6 +61,7 @@
                   "public_302" : "Visible redirect (302, temporary). Everybody will be able to access it.",
                   "public_301" : "Visible redirect (301, permanent). Everybody will be able to access it.",
                   "public_proxy": "Proxy, invisible (nginx proxy_pass). Everybody will be able to access it.",
+				  "public_direct": "Proxy, invisible direct (nginx proxy_pass). Everybody will be able to access it. No forward headers.",
                   "private_proxy": "Proxy, invisible (nginx proxy_pass). Only accessible for allowed users."
                 },
                 "default": "public_302"

--- a/scripts/install
+++ b/scripts/install
@@ -54,6 +54,10 @@ elif [ "$redirect_type" = "public_301" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-visible-301.conf
     cp ../conf/nginx-visible-301.conf /etc/nginx/conf.d/$domain.d/$app.conf
+elif [ "$redirect_type" = "public_direct" ];
+then
+    ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-proxy-direct.conf
+    cp ../conf/nginx-proxy-direct.conf /etc/nginx/conf.d/$domain.d/$app.conf
 elif [ "$redirect_type" = "public_proxy" ] || [ "$redirect_type" = "private_proxy" ];
 then
     ynh_replace_string "YNH_REDIRECT_PATH" "$redirect_path" ../conf/nginx-proxy.conf


### PR DESCRIPTION
In the case of hosting an application like myapp.mydomain.com and trying to redirect www.myapp.com -> myapp.mydomain.com it would always fail with a 502 gateway error.

This should fix that.