### PR TITLE
[fix] HTTP redirection support suburl

### DIFF
--- a/conf/nginx-visible-301.conf
+++ b/conf/nginx-visible-301.conf
@@ -1,3 +1,3 @@
 location YNH_LOCATION {
-  return 301 YNH_REDIRECT_PATH;
+  return 301 YNH_REDIRECT_PATH$request_uri;
 }

--- a/conf/nginx-visible-302.conf
+++ b/conf/nginx-visible-302.conf
@@ -1,3 +1,3 @@
 location YNH_LOCATION {
-  return 302 YNH_REDIRECT_PATH;
+  return 302 YNH_REDIRECT_PATH$request_uri;
 }


### PR DESCRIPTION
Without this fix if you call https://domainA.tld/SUBURL it redirects to  https://domainB.tld/ instead of https://domainB.tld/SUBURL