### PR TITLE
Add option for the yunohost overlay

### DIFF
--- a/conf/nginx-reverseproxy.conf
+++ b/conf/nginx-reverseproxy.conf
@@ -9,12 +9,12 @@ location __PATH__/ {
   proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header  X-Forwarded-Host $server_name;
   proxy_set_header  X-Forwarded-Port $server_port;
-  
+
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
 
-  # Include SSOWAT user panel.
-  include conf.d/yunohost_panel.conf.inc;
-  more_clear_input_headers 'Accept-Encoding';
+  __OVERLAY_COMMENT__# Include SSOWAT user panel.
+  __OVERLAY_COMMENT__include conf.d/yunohost_panel.conf.inc;
+  __OVERLAY_COMMENT__more_clear_input_headers 'Accept-Encoding';
 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -48,6 +48,12 @@ ram.runtime = "50M"
     type = "url"
     help = "This may be something like https://some.other.website (for explicit redirect) or http://127.0.0.1:1234 for reverse-proxies."
 
+    [install.ynh_overlay]
+    ask.en = "Enable the YunoHost button overlay"
+    ask.fr = "Active le button superposé YunoHost"
+    type = "boolean"
+    default = true
+
     [install.init_main_permission]
     type = "group"
     default = "visitors"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,3 +14,12 @@ _validate_redirect_uri() {
         ynh_die --message="For secure reason, you can't use an unencrypted http remote destination couple with ssowat for your reverse proxy: $target" 1
     fi
 }
+
+_set_ynh_overlay() {
+    # Set the comment (or not) for the yunohost overlay
+    overlay_comment=""
+    if [[ "$ynh_overlay" == 0 ]]; then
+        overlay_comment="# "
+    fi
+    ynh_app_setting_set --app=$app --key=overlay_comment --value="$overlay_comment"
+}

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -9,6 +9,8 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
+_set_ynh_overlay
+
 #=================================================
 # STANDARD MODIFICATIONS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -11,6 +11,8 @@ source /usr/share/yunohost/helpers
 
 _validate_redirect_uri
 
+_set_ynh_overlay
+
 #=================================================
 # CONFIGURE NGINX
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,13 @@ if [[ -z "${target:-}" ]] && [[ -n "${redirect_path:-}" ]]; then
     ynh_app_setting_set --app=$app --key=target --value="$target"
 fi
 
+if [[ -z "${ynh_overlay:-}" ]]; then
+    ynh_overlay=1
+    ynh_app_setting_set --app=$app --key=ynh_overlay --value="$ynh_overlay"
+fi
+
+_set_ynh_overlay
+
 #=================================================
 # CONFIGURE NGINX
 #=================================================


### PR DESCRIPTION
tl;dr when redirecting the whole (sub)domain to another machine yunohost overlay won't be available, resulting in crappy 404s.