### PR TITLE
Testing | only display a warning when people are reverseproxying to an external IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ There two typical use cases are covered:
 
 
 **Shipped version:** 2.0~ynh3
-
 ## Documentation and resources
 
 * Official app website: <https://en.wikipedia.org/wiki/Reverse_proxy>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There two typical use cases are covered:
 - **reverse-proxy** : create an app tile to expose an app listening on a specific port, typically something that you manually installed (with or without Docker) locally or on another machine.
 
 
-**Shipped version:** 2.0~ynh1
+**Shipped version:** 2.0~ynh3
 ## Documentation and resources
 
 * Official app website: <https://en.wikipedia.org/wiki/Reverse_proxy>

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Ces deux cas d'usage sont gérés:
 - **reverse-proxy** : créer une tuile pour une application locale qui écoute sur un port donné, typiquement quelque chose que vous avez installé manuellement (avec ou sans Docker), sur cette machine ou sur une autre machine.
 
 
-**Version incluse :** 2.0~ynh1
+**Version incluse :** 2.0~ynh3
 ## Documentations et ressources
 
 * Site officiel de l’app : <https://en.wikipedia.org/wiki/Reverse_proxy>

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,7 +24,6 @@ Ces deux cas d'usage sont gérés:
 
 
 **Version incluse :** 2.0~ynh3
-
 ## Documentations et ressources
 
 * Site officiel de l’app : <https://en.wikipedia.org/wiki/Reverse_proxy>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Redirect"
 description.en = "Create a redirection or a proxy to another path"
 description.fr = "Créer une redirection ou un proxy vers un autre emplacement"
 
-version = "2.0~ynh1"
+version = "2.0~ynh3"
 
 maintainers = []
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,6 +11,6 @@ _validate_redirect_uri() {
     # Avoid uncrypted remote destination with reverse proxy mode
     # Indeed the SSO send the password in all requests in HTTP headers
     if [[ "$redirect_type" = "reverseproxy" ]] && [[ ! $target =~ $URL_REGEX_SECURE ]]; then
-        ynh_die --message="For secure reason, you can't use an unencrypted http remote destination couple with ssowat for your reverse proxy: $target" 1
+        ynh_print_warn --message="Reverseproxying using cleartext HTTP to a possibly external machine ($target) is insecure ... please be super careful about this."
     fi
 }


### PR DESCRIPTION
People complaining about this in https://forum.yunohost.org/t/reverse-proxy-http-not-allowed/27951