### PR TITLE
main.auth_header = false

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -60,3 +60,4 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.auth_header = false


### PR DESCRIPTION
otherwise it can conflict with other authentication header from the redirected app
and since this package doesn't support SSO...

cf a previous discussion on the "YunoHost development" matrix chat